### PR TITLE
Update MalioPay.php

### DIFF
--- a/app/Services/Gateway/MalioPay.php
+++ b/app/Services/Gateway/MalioPay.php
@@ -365,7 +365,7 @@ class MalioPay extends AbstractPayment
                         exit();
                 }
         
-                http_response_code(200);
+               return http_response_code(200);
             case ('wolfpay'):
                 $type = $args['method'];
                 $settings = Config::get("wolfpay") ['config'];


### PR DESCRIPTION
缺少return 导致switch没有跳出,继续向下执行,stripe回调显示有意外失败...虽然没有影响回调的具体操作,但是还是应该修复一下